### PR TITLE
fix encoder conversion

### DIFF
--- a/src/Factors.cpp
+++ b/src/Factors.cpp
@@ -5,13 +5,13 @@ using namespace motors_elmo_ds402;
 
 double Factors::rawToEncoder(int64_t encoder) const
 {
-    return static_cast<double>(encoder) *
+    return encoderScaleFactor * static_cast<double>(encoder) *
         positionNumerator / positionDenominator;
 }
 
 int64_t Factors::rawFromEncoder(double encoder) const
 {
-    return static_cast<double>(encoder) *
+    return encoder / encoderScaleFactor *
         positionDenominator / positionNumerator;
 }
 
@@ -38,7 +38,6 @@ double Factors::rawToTorque(long raw) const
 void Factors::update()
 {
     positionNumerator =
-        encoderScaleFactor *
         feedLength *
         encoderRevolutions *
         gearDrivingShaftRevolutions;


### PR DESCRIPTION
encoderScaleFactor is a double, but was converted to integer through
the positionNumerator coefficient.