### PR TITLE
never override parameters provided explicitly by CAN-provided factors

### DIFF
--- a/src/Controller.cpp
+++ b/src/Controller.cpp
@@ -95,6 +95,8 @@ canbus::Message Controller::setTorqueTarget(double target)
 
 void Controller::setMotorParameters(MotorParameters const& parameters)
 {
+    mMotorParameters = parameters;
+
     if (parameters.encoderTicks)
         setRaw<PositionEncoderResolutionNum>(parameters.encoderTicks);
     if (parameters.encoderRevolutions)
@@ -206,10 +208,10 @@ Update Controller::process(canbus::Message const& msg)
     }
 
     if (update & UPDATE_FACTORS) {
-        try {
-            mFactors = computeFactors();
-        }
-        catch(canopen_master::ObjectNotRead) {}
+        // If the user explicitely wrote motor parameters, we apply them again
+        // The method re-computed the factors. There's no need to do it
+        // explicitely
+        setMotorParameters(mMotorParameters);
     }
 
     return Update::UpdatedObjects(update);

--- a/src/Controller.hpp
+++ b/src/Controller.hpp
@@ -201,6 +201,7 @@ namespace motors_elmo_ds402 {
 
         int64_t mZeroPosition = 0;
 
+        MotorParameters mMotorParameters;
         Factors computeFactors() const;
 
         template<typename T>


### PR DESCRIPTION
The issue this fixes is in a case where the parameters are not stored
in the controller. In this case, some or all of the parameters are
passed explicitly with setMotorParameters

However, if for whatever reason some of the factor objects are read,
when received and processed by the controller, these factor objects
will reset the values set explicitly.

Change the behavior to always consider the explicit motor parameters
to be of a higher priority than the ones coming from the device.